### PR TITLE
Fix Issue #237 with stop-gap measure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ _testdata
 .coverage
 .noseids
 1
+pyenv/
 *.egg-info
 docs/_build

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,8 +115,6 @@ Example API call:
 policy-marker
 `````````````
 
-*The IATI Tech team have uncovered issues with this filter (‘500 internal server error’). `This issue has been logged <https://github.com/IATI/iati-datastore/issues/237>`__ and we will endeavour to resolve this shortly.*
-
 Returns activities containing a `policy-marker <http://iatistandard.org/201/activity-standard/iati-activities/iati-activity/policy-marker/>`__ element which matches a your specified policy-marker value.
 
 Parameters:

--- a/iati_datastore/iatilib/codelists/enum.py
+++ b/iati_datastore/iatilib/codelists/enum.py
@@ -86,6 +86,8 @@ class DeclEnumType(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
+        elif isinstance(value, basestring):
+            return value
         return value.value
 
     def process_result_value(self, value, dialect):

--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -16,8 +16,8 @@ from iatilib.loghandlers import DatasetMessage as _
 
 log = logging.getLogger("crawler")
 
-CKAN_WEB_BASE = 'http://www.iatiregistry.org/dataset/%s'
-CKAN_API = 'http://www.iatiregistry.org/'
+CKAN_WEB_BASE = 'https://www.iatiregistry.org/dataset/%s'
+CKAN_API = 'https://www.iatiregistry.org/'
 
 registry = ckanapi.RemoteCKAN(CKAN_API)
 


### PR DESCRIPTION
This fixes issue #237 and stops 500 status codes being returned by the policy-marker filter.

It is a stop-gap measure, and a full investigation has not been undertaken to resolve why the 500 error was occurring - enums are passed around for other filters, however certain strings are not converted to enums in the case of policy-marker. Why this is the case is currently unknown.