### PR TITLE
Reduce csv 500 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _testdata
 1
 *.egg-info
 docs/_build
+pyenv/

--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -58,8 +58,8 @@ def about_dataset(dataset):
             'last_successful_fetch': r.last_succ.isoformat() if r.last_succ else None,
             'last_parsed': r.last_parsed.isoformat() if r.last_parsed else None,
             'num_of_activities': r.activities.count(),
-        }) 
-        
+        })
+
     return jsonify(
             dataset=dataset.name,
             last_modified=None if dataset.last_modified is None else dataset.last_modified.isoformat(),
@@ -72,11 +72,11 @@ def deleted_activities():
     deleted_activities = db.session.query(DeletedActivity)\
                                    .order_by(DeletedActivity.deletion_date)
     return jsonify(
-        deleted_activities=[ 
+        deleted_activities=[
           {
             'iati_identifier' : da.iati_identifier,
             'deletion_date' : da.deletion_date.isoformat(),
-          } 
+          }
           for da in deleted_activities
         ],
     )
@@ -132,7 +132,7 @@ def dataset_error(dataset_id):
 def dataset_log():
     logs = db.session.query(Log.dataset).distinct()
     return render_template('datasets.log', logs=logs)
-    
+
 @api.route('/error/dataset.log/<dataset_id>')
 def dataset_log_error(dataset_id):
     error_logs = db.session.query(Log).order_by(sa.desc(Log.created_at)).\

--- a/iati_datastore/iatilib/frontend/serialize/csv.py
+++ b/iati_datastore/iatilib/frontend/serialize/csv.py
@@ -96,7 +96,7 @@ def transaction_tied_status(transaction):
 
 def transaction_disbursement_channel(transaction):
     if transaction.disbursement_channel:
-        return transaction.disbursement_channel.value 
+        return transaction.disbursement_channel.value
     return ""
 
 def transaction_org(field, transaction):
@@ -147,10 +147,16 @@ def recipient_region_percentage(activity):
         for rrp in activity.recipient_region_percentages)
 
 def reporting_org_ref(activity):
-    return activity.reporting_org.ref
+    try:
+        return activity.reporting_org.ref
+    except AttributeError:
+        return ""
 
 def reporting_org_name(activity):
-    return activity.reporting_org.name
+    try:
+        return activity.reporting_org.name
+    except AttributeError:
+        return ""
 
 def reporting_org_type(activity):
     try:
@@ -209,7 +215,7 @@ def value_currency(transaction):
     if transaction.value_currency:
         return transaction.value_currency.value
     else:
-        return u"" 
+        return u""
 
 def activity_default_currency(activity):
     if activity.default_currency:
@@ -439,7 +445,7 @@ def adapt_activity_other(func):
 
 
 csv_activity_by_country = CSVSerializer((
-    (u"recipient-country-code", lambda (a, c): c.country.value if c.country else ""), 
+    (u"recipient-country-code", lambda (a, c): c.country.value if c.country else ""),
     (u"recipient-country", lambda (a, c): c.country.description.title() if c.country and c.country.description else ""),
     (u"recipient-country-percentage", lambda (a, c): c.percentage if c.percentage else ""),
     "iati-identifier",


### PR DESCRIPTION
This adds additional error checking to reduce the cases where attempting
to view CSV-formatted activity files will return a 500 error.

This fixes API calls such as:
    /api/1/access/activity.csv?limit=1