### PR TITLE
Make csv route checking a bit stricter

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -223,7 +223,7 @@ class ActivityView(DataStoreView):
 
 class DataStoreCSVView(DataStoreView):
     def get(self, format=".csv"):
-        if not request.path.endswith("csv"):
+        if format != ".csv":
             abort(404)
         return self.get_response()
 


### PR DESCRIPTION
Check value of format, rather than checking how the path ends.

Fixes #250.