### PR TITLE
[#247] Demonstrate regexp matching

### DIFF
--- a/iati_datastore/iatilib/frontend/dsfilter.py
+++ b/iati_datastore/iatilib/frontend/dsfilter.py
@@ -27,7 +27,7 @@ def _filter(query, args):
     #    Activity.recipient_country_percentages, CountryPercentage.country)
     def recipient_country(country_code):
         return Activity.recipient_country_percentages.any(
-            CountryPercentage.country == country_code
+            CountryPercentage.country.op('regexp')(r'\s*{}\s*'.format(country_code))
         )
 
     def recipient_country_text(country):

--- a/iati_datastore/iatilib/frontend/dsfilter.py
+++ b/iati_datastore/iatilib/frontend/dsfilter.py
@@ -27,7 +27,7 @@ def _filter(query, args):
     #    Activity.recipient_country_percentages, CountryPercentage.country)
     def recipient_country(country_code):
         return Activity.recipient_country_percentages.any(
-            CountryPercentage.country.op('regexp')(r'\s*{}\s*'.format(country_code))
+            CountryPercentage.country.op('~')('\s*{}\s*'.format(country_code))
         )
 
     def recipient_country_text(country):


### PR DESCRIPTION
This adds a demonstration on how to perform regexp matching of values when querying the Datastore. It allows whitespace to be matched, while still returning the original values.

Once this has been tested on the staging server, similar will be done to other filters. Once that works, it can be deployed to live.