### PR TITLE
Add test for CSV route checking

### DIFF
--- a/iati_datastore/iatilib/frontend/api1.py
+++ b/iati_datastore/iatilib/frontend/api1.py
@@ -222,7 +222,7 @@ class ActivityView(DataStoreView):
 
 
 class DataStoreCSVView(DataStoreView):
-    def get(self, format=".csv"):
+    def get(self, format):
         if format != ".csv":
             abort(404)
         return self.get_response()

--- a/iati_datastore/iatilib/test/test_api.py
+++ b/iati_datastore/iatilib/test/test_api.py
@@ -250,6 +250,15 @@ class ApiViewMixin(object):
         resp = self.client.get(self.base_url + ".zzz")
         self.assertEquals(404, resp.status_code)
 
+    def test_junk_before_format(self):
+        url = self.base_url[:-4] + '-bad.csv'
+        resp = self.client.get(url)
+        self.assertEquals(404, resp.status_code)
+
+    def test_junk_in_format(self):
+        url = self.base_url[:-4] + '.bad-csv'
+        resp = self.client.get(url)
+        self.assertEquals(404, resp.status_code)
 
 class TestActivityView(ClientTestCase, ApiViewMixin):
     base_url = '/api/1/access/activity.csv'


### PR DESCRIPTION
Adds tests that fails before 199d9dd3 and pass after.
Also removes default parameter value since it is not used.

Refs #258; Fixes #250.