### PR TITLE
Use last parsed date in `If-Modified-Since` header

### DIFF
--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -161,8 +161,8 @@ def fetch_resource(resource):
     :return:
     '''
     headers = {}
-    if resource.last_succ:
-        headers['If-Modified-Since'] = http_date(resource.last_succ)
+    if resource.last_parsed:
+        headers['If-Modified-Since'] = http_date(resource.last_parsed)
     if resource.etag:
         headers["If-None-Match"] = resource.etag.encode('ascii')
     resp = requests.get(resource.url, headers=headers)


### PR DESCRIPTION
(instead of last successful fetch date.)

NB I’m not totally sure about this! It will mean some unparseable resources that correctly serve 304s will be fetched unnecessarily. Also, it’s not totally clear if this is the correct solution anyway.

It should fix #268, though – i.e. in this very specific case, switching these dates results in a `200` response rather than a `304`, and the data is updated.