### PR TITLE
Update version of six to match requirements.txt

### DIFF
--- a/iati_datastore/setup.py
+++ b/iati_datastore/setup.py
@@ -11,7 +11,7 @@ iso8601==0.1.4
 lxml==3.4.1
 psycopg2==2.4.6
 python-dateutil==2.1
-six==1.2.0
+six==1.10.0
 unicodecsv==0.9.4
 voluptuous==0.7.1
 Flask-Script==0.5.3


### PR DESCRIPTION
requirements.txt was updated in 5e2d5fa5. This makes the corresponding change in iati_datastore/setup.py