### PR TITLE
Fix travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For example, on Ubuntu:
 Installing for development
 --------------------------
 
-[![Build Status](https://api.travis-ci.org/IATI/IATI-Datastore.png)](https://travis-ci.org/IATI/iati-datastore)
+[![Build Status](https://api.travis-ci.org/IATI/IATI-Datastore.png)](https://travis-ci.org/IATI/IATI-Datastore)
 
 ```
 # Clone the source

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For example, on Ubuntu:
 Installing for development
 --------------------------
 
-[![Build Status](https://api.travis-ci.org/IATI/IATI-Datastore.png)](https://travis-ci.org/IATI/IATI-Datastore)
+[![Build Status](https://travis-ci.org/IATI/IATI-Datastore.svg?branch=master)](https://travis-ci.org/IATI/IATI-Datastore)
 
 ```
 # Clone the source

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ For example, on Ubuntu:
 Installing for development
 --------------------------
 
-[![Build Status](https://travis-ci.org/IATI/IATI-Datastore.svg?branch=master)](https://travis-ci.org/IATI/IATI-Datastore)
-
 ```
 # Clone the source
 git clone https://github.com/IATI/IATI-Datastore.git


### PR DESCRIPTION
The README shows two travis badges; one says the build is passing, the other failing.

I *think* that’s because one is for the master branch and the other is for the last build.

This makes them both show the build status for the master branch.