### PR TITLE
Update codelists

### DIFF
--- a/iati_datastore/iatilib/codelists/__init__.py
+++ b/iati_datastore/iatilib/codelists/__init__.py
@@ -24,7 +24,7 @@ def iati_url(name):
     return {
         '1': ("http://iatistandard.org/105/codelists/downloads/clv2/csv/en/" +
               "%s.csv" % (name)),
-        '2': ("http://dev.iatistandard.org/201/codelists/downloads/clv2/csv/en/" +
+        '2': ("http://iatistandard.org/201/codelists/downloads/clv2/csv/en/" +
               "%s.csv" % (name)),
     }
 

--- a/iati_datastore/iatilib/codelists/__init__.py
+++ b/iati_datastore/iatilib/codelists/__init__.py
@@ -24,7 +24,7 @@ def iati_url(name):
     return {
         '1': ("http://iatistandard.org/105/codelists/downloads/clv2/csv/en/" +
               "%s.csv" % (name)),
-        '2': ("http://iatistandard.org/201/codelists/downloads/clv2/csv/en/" +
+        '2': ("http://iatistandard.org/202/codelists/downloads/clv2/csv/en/" +
               "%s.csv" % (name)),
     }
 

--- a/iati_datastore/iatilib/console.py
+++ b/iati_datastore/iatilib/console.py
@@ -36,9 +36,9 @@ def download_codelists():
             print "Downloading %s.xx %s" % (major_version, name)
             resp = requests.get(url[major_version])
             resp.raise_for_status()
-            assert len(resp.text) > 0, "Response is empty"
+            assert len(resp.content) > 0, "Response is empty"
             with codecs.open(filename, "w", encoding="utf-8") as cl:
-                cl.write(resp.text)
+                cl.write(resp.content.decode('utf-8'))
 
 
 @manager.command


### PR DESCRIPTION
Run the version of `iati download_codelists` on #283, in order to pull in the latest versions of all codelists.

Some tests appear to rely on specific codes that have been renamed, so those are also updated.