### PR TITLE
Add requires.io filters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psycopg2==2.4.6  # rq.filter: <3.0
 python-dateutil==2.1  # rq.filter: <2.5
 six==1.10.0  # rq.filter: <2.0
 unicodecsv==0.9.4  # rq.filter: <0.10
-voluptuous==0.7.1  # rq.filter: <0.8
+voluptuous==0.7.1  # rq.filter: ==0.7.1
 Flask-Script==0.5.3  # rq.filter: <0.6
 prettytable==0.7  # rq.filter: <0.8
 alembic==0.5.0  # rq.filter: <0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ ckanapi==1.5  # rq.filter: <2.0
 iso8601==0.1.4  # rq.filter: <0.2
 lxml==3.4.1  # rq.filter: <4.0
 psycopg2==2.4.6  # rq.filter: <3.0
-python-dateutil==2.1  # rq.filter: <3.0
+python-dateutil==2.1  # rq.filter: <2.5
 six==1.10.0  # rq.filter: <2.0
 unicodecsv==0.9.4  # rq.filter: <0.10
 voluptuous==0.7.1  # rq.filter: <0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,32 +2,32 @@
 
 # If you update these, also update iati_datastore/setup.py
 # These are duplicated here so that requires.io will flag out of date dependencies
-Flask==0.10
-Jinja2==2.6
-SQLAlchemy==0.8
-Flask-SQLAlchemy==1.0
-Werkzeug==0.8.3
-ckanapi==1.5
-iso8601==0.1.4
-lxml==3.4.1
-psycopg2==2.4.6
-python-dateutil==2.1
-six==1.10.0
-unicodecsv==0.9.4
-voluptuous==0.7.1
-Flask-Script==0.5.3
-prettytable==0.7
-alembic==0.5.0
-gunicorn==0.17.2
-defusedxml==0.4
-redis==2.7.2
-rq==0.3.7
-Unidecode==0.04.12
-requests==2.5.3
-Flask-RQ==0.2
-flask-heroku==0.1.4
-Flask-And-Redis==0.4
-Flask-Markdown==0.3
-xmltodict==0.7.0
-gevent>=0.13.8
+Flask==0.10  # rq.filter: <0.11
+Jinja2==2.6  # rq.filter: <3.0
+SQLAlchemy==0.8  # rq.filter: <0.9
+Flask-SQLAlchemy==1.0  # rq.filter: <2.0
+Werkzeug==0.8.3  # rq.filter: <0.9
+ckanapi==1.5  # rq.filter: <2.0
+iso8601==0.1.4  # rq.filter: <0.2
+lxml==3.4.1  # rq.filter: <4.0
+psycopg2==2.4.6  # rq.filter: <3.0
+python-dateutil==2.1  # rq.filter: <3.0
+six==1.10.0  # rq.filter: <2.0
+unicodecsv==0.9.4  # rq.filter: <0.10
+voluptuous==0.7.1  # rq.filter: <0.8
+Flask-Script==0.5.3  # rq.filter: <0.6
+prettytable==0.7  # rq.filter: <0.8
+alembic==0.5.0  # rq.filter: <0.6
+gunicorn==0.17.2  # rq.filter: <0.18
+defusedxml==0.4  # rq.filter: <0.5
+redis==2.7.2  # rq.filter: <3.0
+rq==0.3.7  # rq.filter: <0.4
+Unidecode==0.04.12  # rq.filter: <0.05
+requests==2.5.3  # rq.filter: <3.0
+Flask-RQ==0.2  # rq.filter: <0.3
+flask-heroku==0.1.4  # rq.filter: <0.2
+Flask-And-Redis==0.4  # rq.filter: <0.5
+Flask-Markdown==0.3  # rq.filter: <0.4
+xmltodict==0.7.0  # rq.filter: <0.8
+gevent==0.13.8  # rq.filter: <0.14
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,10 @@
 # If you update these, also update iati_datastore/setup.py
 -r requirements.txt
-nose==1.2.1
-mock==1.0.1
-factory-boy==1.2.0
-coveralls==0.5
-coverage==3.7.1
+nose==1.2.1  # rq.filter: <2.0
+mock==1.0.1  # rq.filter: <2.0
+factory-boy==1.2.0  # rq.filter: <2.0
+coveralls==0.5  # rq.filter: <0.6
+coverage==3.7.1  # rq.filter: <4.0
 
 # for acceptance tests
-html==1.16
+html==1.16  # rq.filter: <2.0


### PR DESCRIPTION
This adds filters so that requires.io only suggests changes that should not cause backwards incompatibilities to be introduced.

This is done by assuming SemVer for all dependencies. Whether or not this assumption is valid for all is to be seen, but is about the best bet that can be made.

This PR replaces #266 and #287, both of which are failing attempts at doing this very thing.