### PR TITLE
Update psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Werkzeug==0.8.3  # rq.filter: <0.9
 ckanapi==1.5  # rq.filter: <2.0
 iso8601==0.1.4  # rq.filter: <0.2
 lxml==3.4.1  # rq.filter: <4.0
-psycopg2==2.4.6  # rq.filter: <3.0
+psycopg2==2.7.3.2  # rq.filter: <3.0
 python-dateutil==2.1  # rq.filter: <2.5
 six==1.10.0  # rq.filter: <2.0
 unicodecsv==0.9.4  # rq.filter: <0.10


### PR DESCRIPTION
Updates psycopg2 to the latest version. This is needed as Travis runs a later version of postgres but the with an incompatible version. This causes all travis builds to fail, for example: https://travis-ci.org/IATI/IATI-Datastore/builds/327278368  It appears that requires.io is not properly working, which awaits further investigation.