### PR TITLE
Coverage should only include iati_datastore

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source =
+    iati_datastore

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 source =
     iati_datastore
+omit =
+    */test/*


### PR DESCRIPTION
This excludes dependencies from coverage tests.

It also excludes all test files.