### PR TITLE
Update base URLs for the Registry

### DIFF
--- a/iati_datastore/iatilib/crawler.py
+++ b/iati_datastore/iatilib/crawler.py
@@ -16,8 +16,8 @@ from iatilib.loghandlers import DatasetMessage as _
 
 log = logging.getLogger("crawler")
 
-CKAN_WEB_BASE = 'https://www.iatiregistry.org/dataset/%s'
-CKAN_API = 'https://www.iatiregistry.org'
+CKAN_WEB_BASE = 'https://iatiregistry.org/dataset/%s'
+CKAN_API = 'https://iatiregistry.org'
 
 registry = ckanapi.RemoteCKAN(CKAN_API)
 


### PR DESCRIPTION
As part of the migration of the IATI Registry to a new supplier, the Registry is now hosted at https://iatiregistry.org with 301 redirects from URLs prepended with `http` and/or `www`.

However, the ckanapi package cannot handle 301 redirects, which caused ValidationError exceptions on the `301 Moved Permanently` content that was returned. This commit updates the URLs so that expected content is returned.